### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Run link check

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # This step checks out a copy of your repository.
       - name: Checkout Milvus Helm
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944